### PR TITLE
[BEAM-2311] Fixed world initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This sample project demonstrates specific [Beamable](https://beamable.com/) feat
 
 **Project Configuration**
 * `Unity Target` - Standalone MAC/PC
-* `Unity Version` - Use this [Version](./client/ProjectSettings/ProjectVersion.txt) or above
+* `Unity Version` - Use this [Version](./client/ProjectSettings/ProjectVersion.txt)
 * `Unity Rendering` - [Universal Render Pipeline (URP)](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@10.2/manual/index.html)
 
 **Project Physics**

--- a/client/Assets/Scenes/1.Intro.unity
+++ b/client/Assets/Scenes/1.Intro.unity
@@ -332,6 +332,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1413401271}
+  - component: {fileID: 1413401272}
   m_Layer: 0
   m_Name: World
   m_TagString: Untagged
@@ -356,6 +357,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1413401272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413401270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a78c94c2fb9a54f4da740e5fd7cc411c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1617702623
 GameObject:
   m_ObjectHideFlags: 0
@@ -398,6 +411,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
   m_RenderPostProcessing: 0
   m_Antialiasing: 0
   m_AntialiasingQuality: 2

--- a/client/Assets/Scripts/Runtime/Beamable/Samples/KOR/ECS/WorldInitializer.cs
+++ b/client/Assets/Scripts/Runtime/Beamable/Samples/KOR/ECS/WorldInitializer.cs
@@ -1,0 +1,16 @@
+using Unity.Entities;
+using UnityEngine;
+
+/// <summary>
+/// Calls DefaultWorldInitialization.Initialize() if UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP is enabled.
+/// Prevents the world from initializing before the scene catalog is loaded.
+/// </summary>
+public class WorldInitializer : MonoBehaviour
+{
+    private void Awake()
+    {
+#if UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP
+        World.DefaultGameObjectInjectionWorld = DefaultWorldInitialization.Initialize("Default World");
+#endif  
+    }
+}

--- a/client/Assets/Scripts/Runtime/Beamable/Samples/KOR/ECS/WorldInitializer.cs.meta
+++ b/client/Assets/Scripts/Runtime/Beamable/Samples/KOR/ECS/WorldInitializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a78c94c2fb9a54f4da740e5fd7cc411c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/ProjectSettings/ProjectSettings.asset
+++ b/client/ProjectSettings/ProjectSettings.asset
@@ -672,7 +672,8 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    1: UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}


### PR DESCRIPTION
https://disruptorbeam.atlassian.net/browse/BEAM-2311

The bug originally reported was "AssertionException: The scene catalog has not been loaded yet". This is resolved by disabling automatic world initialization via `UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP` scripting define, and initializing the world from a MonoBehaviour in the Intro scene.